### PR TITLE
feat: hierarchical routes and relationships

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -285,7 +285,24 @@
         if (base && jwt) {
           const u = base + '/wp-json/myapp/v1/pdvs_all';
           const r = await fetch(u, { headers: { Authorization: 'Bearer ' + jwt } });
-          if (r.ok) return r.json();
+          if (r.ok) {
+            const data = await r.json();
+            const flat = [];
+            (data || []).forEach((route) => {
+              const rInfo = { id: route.id, title: route.title };
+              (route.subroutes || []).forEach((sr) => {
+                const sInfo = { id: sr.id, title: sr.title };
+                (sr.pdvs || []).forEach((p) => {
+                  flat.push({
+                    ...p,
+                    route: rInfo,
+                    subroute: sInfo,
+                  });
+                });
+              });
+            });
+            return flat;
+          }
         }
       } catch (e) {}
 


### PR DESCRIPTION
## Summary
- support hierarchical `tt_route` post type with slug `ruta`
- use Meta Box relationships to link routes, sub-routes and PDVs
- expose nested PDV catalog and adjust PWA fetch

## Testing
- `php -l plugin/ttpro-wpapi.php`
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7527f596483278c0a04725aa16865