### PR TITLE
feat: hierarchical routes and relationships

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -285,7 +285,24 @@
         if (base && jwt) {
           const u = base + '/wp-json/myapp/v1/pdvs_all';
           const r = await fetch(u, { headers: { Authorization: 'Bearer ' + jwt } });
-          if (r.ok) return r.json();
+          if (r.ok) {
+            const data = await r.json();
+            const flat = [];
+            (data || []).forEach((route) => {
+              const rInfo = { id: route.id, title: route.title };
+              (route.subroutes || []).forEach((sr) => {
+                const sInfo = { id: sr.id, title: sr.title };
+                (sr.pdvs || []).forEach((p) => {
+                  flat.push({
+                    ...p,
+                    route: rInfo,
+                    subroute: sInfo,
+                  });
+                });
+              });
+            });
+            return flat;
+          }
         }
       } catch (e) {}
 

--- a/plugin/ttpro-wpapi.php
+++ b/plugin/ttpro-wpapi.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: TT PRO API
 Description: Endpoints para Todo Terreno PRO. CPTs de Rutas y PDVs. Devuelve PDVs del usuario y recibe respuestas (foto como imagen destacada, metadatos y usuario que llenó). Incluye seeder (UI en Herramientas).
-Version: 1.8.1
+Version: 1.9.0
 Author: TT
 */
 if (!defined('ABSPATH')) exit;
@@ -10,6 +10,7 @@ if (!defined('ABSPATH')) exit;
 class TTPro_Api {
   public function __construct() {
     add_action('init',               [$this,'register_cpts']);
+    add_action('mb_relationships_init', [$this,'register_relationships']);
     add_action('rest_api_init',      [$this,'register_routes']);
     add_action('admin_menu',         [$this,'admin_menu']);
     add_action('admin_post_ttpro_seed_demo', [$this,'handle_seed_demo']);
@@ -26,6 +27,8 @@ class TTPro_Api {
       'supports'     => ['title','author','custom-fields'],
       'show_in_rest' => false,
       'menu_position'=> 25,
+      'hierarchical' => true,
+      'rewrite'      => ['slug' => 'ruta', 'with_front' => false],
     ]);
 
     register_post_type('tt_pdv', [
@@ -43,21 +46,62 @@ class TTPro_Api {
     add_meta_box('tt_pdv_meta',   'Metadatos de PDV',   [$this,'render_pdv_meta'],   'tt_pdv');
   }
 
+  public function register_relationships() {
+    if (!class_exists('MB_Relationships_API')) return;
+
+    MB_Relationships_API::register([
+      'id'   => 'route_user',
+      'from' => [
+        'object_type' => 'post',
+        'post_type'   => 'tt_route',
+        'meta_box'    => [ 'title' => 'Vendedores' ],
+      ],
+      'to'   => [
+        'object_type' => 'user',
+        'meta_box'    => [ 'title' => 'Rutas asignadas' ],
+      ],
+      'reciprocal' => true,
+    ]);
+
+    MB_Relationships_API::register([
+      'id'   => 'subroute_pdv',
+      'from' => [
+        'object_type' => 'post',
+        'post_type'   => 'tt_route',
+        'meta_box'    => [ 'title' => 'Puntos de venta' ],
+      ],
+      'to'   => [
+        'object_type' => 'post',
+        'post_type'   => 'tt_pdv',
+        'meta_box'    => [ 'title' => 'Sub-ruta' ],
+      ],
+    ]);
+  }
+
   public function render_route_meta($post) {
     $meta = get_post_meta($post->ID);
     echo '<h4>Metadatos</h4><pre>' . esc_html(print_r($meta, true)) . '</pre>';
 
-    $pdvs = get_posts([
-      'post_type'  => 'tt_pdv',
+    $subroutes = get_posts([
+      'post_type'  => 'tt_route',
       'numberposts'=> -1,
-      'meta_key'   => '_tt_pdv_route',
-      'meta_value' => $post->ID,
+      'post_parent'=> $post->ID,
+      'post_status'=> 'any'
     ]);
-    if ($pdvs) {
-      echo '<h4>PDVs asignados</h4><ul>';
-      foreach ($pdvs as $p) {
-        $link = get_edit_post_link($p->ID);
-        echo '<li><a href="' . esc_url($link) . '">' . esc_html(get_the_title($p)) . '</a></li>';
+    if ($subroutes) {
+      echo '<h4>Sub-rutas</h4><ul>';
+      foreach ($subroutes as $sr) {
+        $pdvs = [];
+        if (class_exists('MB_Relationships_API')) {
+          $pdvs = MB_Relationships_API::get_connected([
+            'id' => $sr->ID,
+            'relationship' => 'subroute_pdv',
+            'direction' => 'from',
+          ]);
+        }
+        $link = get_edit_post_link($sr->ID);
+        $count = is_array($pdvs) ? count($pdvs) : 0;
+        echo '<li><a href="' . esc_url($link) . '">' . esc_html(get_the_title($sr)) . '</a> (' . intval($count) . ' PDVs)</li>';
       }
       echo '</ul>';
     }
@@ -67,11 +111,22 @@ class TTPro_Api {
     $meta = get_post_meta($post->ID);
     echo '<h4>Metadatos</h4><pre>' . esc_html(print_r($meta, true)) . '</pre>';
 
-    $route_id = (int) get_post_meta($post->ID, '_tt_pdv_route', true);
-    if ($route_id) {
-      $link = get_edit_post_link($route_id);
-      $title = get_the_title($route_id);
-      echo '<p><strong>Ruta asignada:</strong> <a href="' . esc_url($link) . '">' . esc_html($title) . '</a></p>';
+    if (class_exists('MB_Relationships_API')) {
+      $subs = MB_Relationships_API::get_connected([
+        'id' => $post->ID,
+        'relationship' => 'subroute_pdv',
+        'direction' => 'to',
+      ]);
+      if ($subs) {
+        $sub = $subs[0];
+        $route_id = wp_get_post_parent_id($sub->ID);
+        $link = get_edit_post_link($sub->ID);
+        echo '<p><strong>Sub-ruta:</strong> <a href="' . esc_url($link) . '">' . esc_html(get_the_title($sub)) . '</a></p>';
+        if ($route_id) {
+          $linkr = get_edit_post_link($route_id);
+          echo '<p><strong>Ruta:</strong> <a href="' . esc_url($linkr) . '">' . esc_html(get_the_title($route_id)) . '</a></p>';
+        }
+      }
     }
   }
 
@@ -81,18 +136,27 @@ class TTPro_Api {
   }
 
   private function route_assigned_to_user($route_id, $user_id) {
+    if (class_exists('MB_Relationships_API')) {
+      $users = MB_Relationships_API::get_connected([
+        'id' => $route_id,
+        'relationship' => 'route_user',
+        'direction' => 'from',
+      ]);
+      foreach ($users as $u) {
+        if ((int) $u->ID === (int) $user_id) return true;
+      }
+      return false;
+    }
     $assigned = (int) get_post_meta($route_id, '_tt_route_user', true);
     return $assigned === (int)$user_id;
   }
 
-  private function pdv_payload($pdv_id) {
-    $route_id    = (int) get_post_meta($pdv_id, '_tt_pdv_route', true);
+  private function pdv_payload($pdv_id, $route_id = 0, $subroute_id = 0) {
     $status      = (string) get_post_meta($pdv_id, '_tt_pdv_status', true);
     $code        = (string) get_post_meta($pdv_id, '_tt_pdv_code', true);
     $address     = (string) get_post_meta($pdv_id, '_tt_pdv_address', true);
-    $route_title = $route_id ? get_the_title($route_id) : '';
-    $day_id      = (string) get_post_meta($pdv_id, '_tt_pdv_day_id', true);
-    $day_title   = (string) get_post_meta($pdv_id, '_tt_pdv_day_title', true);
+    $route_title    = $route_id ? get_the_title($route_id) : '';
+    $subroute_title = $subroute_id ? get_the_title($subroute_id) : '';
     return [
       'id'      => (string) $pdv_id,
       'code'    => $code ?: '',
@@ -100,7 +164,7 @@ class TTPro_Api {
       'address' => $address ?: '',
       'status'  => $status ?: 'pending', // pending | filled | synced
       'route'   => [ 'id' => (string)$route_id, 'title' => $route_title ],
-      'subroute'=> [ 'id' => (string)$day_id, 'title' => $day_title ],
+      'subroute'=> [ 'id' => (string)$subroute_id, 'title' => $subroute_title ],
     ];
   }
 
@@ -257,22 +321,53 @@ class TTPro_Api {
           $user_id = $this->current_user_id_jwt();
           if (!$user_id) return new WP_Error('tt_no_user','No autenticado', ['status'=>401]);
 
-          // Rutas asignadas al usuario
-          $routes = get_posts([ 'post_type'=>'tt_route','numberposts'=>-1,'post_status'=>'any' ]);
-          $allowed_route_ids = [];
-          foreach ($routes as $r) {
-            if ($this->route_assigned_to_user($r->ID, $user_id)) $allowed_route_ids[] = $r->ID;
+          // Rutas asignadas al usuario mediante relationships
+          $routes = [];
+          if (class_exists('MB_Relationships_API')) {
+            $routes = MB_Relationships_API::get_connected([
+              'id' => $user_id,
+              'relationship' => 'route_user',
+              'direction' => 'to',
+            ]);
           }
-          if (empty($allowed_route_ids)) return [];
-
-          // PDVs en esas rutas
-          $pdvs = get_posts([
-            'post_type'=>'tt_pdv','numberposts'=>-1,'post_status'=>'any',
-            'meta_query'=>[[ 'key'=>'_tt_pdv_route','value'=>$allowed_route_ids,'compare'=>'IN' ]]
-          ]);
+          if (empty($routes)) return [];
 
           $out = [];
-          foreach ($pdvs as $p) $out[] = $this->pdv_payload($p->ID);
+          foreach ($routes as $r) {
+            $route_id = $r->ID;
+            $route_item = [
+              'id' => (string)$route_id,
+              'title' => get_the_title($route_id),
+              'subroutes' => []
+            ];
+            $subroutes = get_posts([
+              'post_type' => 'tt_route',
+              'numberposts' => -1,
+              'post_parent' => $route_id,
+              'post_status' => 'any',
+            ]);
+            foreach ($subroutes as $sr) {
+              $sub_id = $sr->ID;
+              $sub_item = [
+                'id' => (string)$sub_id,
+                'title' => get_the_title($sub_id),
+                'pdvs' => []
+              ];
+              $pdvs = [];
+              if (class_exists('MB_Relationships_API')) {
+                $pdvs = MB_Relationships_API::get_connected([
+                  'id' => $sub_id,
+                  'relationship' => 'subroute_pdv',
+                  'direction' => 'from',
+                ]);
+              }
+              foreach ($pdvs as $p) {
+                $sub_item['pdvs'][] = $this->pdv_payload($p->ID, $route_id, $sub_id);
+              }
+              $route_item['subroutes'][] = $sub_item;
+            }
+            $out[] = $route_item;
+          }
           return $out;
         }
       ]);
@@ -361,51 +456,63 @@ class TTPro_Api {
   /* ===================== Seeder (núcleo + UI) ===================== */
   private function seed_generate($user_id, $routes_n, $pdvs_n) {
     $routes_created = 0; $pdvs_created = 0;
-    $days = [
-      ['id' => 'day_1', 'title' => 'Lunes'],
-      ['id' => 'day_2', 'title' => 'Martes'],
-      ['id' => 'day_3', 'title' => 'Miércoles'],
-      ['id' => 'day_4', 'title' => 'Jueves'],
-      ['id' => 'day_5', 'title' => 'Viernes'],
-    ];
+    $sub_names = ['UN01','UN02','UN03','UN04','UN05'];
 
     for ($i=1; $i<=$routes_n; $i++) {
-      $r_title = 'Ruta Demo '.$i;
+      $r_title = sprintf('VG%02d', $i);
       $route_id = wp_insert_post([
         'post_type'   => 'tt_route',
         'post_status' => 'publish',
         'post_title'  => $r_title,
-        'meta_input'  => [
-          '_tt_route_user' => $user_id,
-          '_tt_demo'       => 1,
-        ],
+        'meta_input'  => [ '_tt_demo' => 1 ],
       ]);
       if (!$route_id || is_wp_error($route_id)) continue;
       $routes_created++;
+      if (class_exists('MB_Relationships_API')) {
+        MB_Relationships_API::add($route_id, $user_id, 'route_user');
+      }
 
-      for ($j=1; $j<=$pdvs_n; $j++) {
-        $code    = sprintf('%02d-%03d', $i, $j);
-        $title   = 'PDV '.$code;
-        $address = 'Calle '.rand(1,99).', Zona '.rand(1,24);
-        $status  = (rand(0,100) < 20) ? 'synced' : 'pending'; // ~20% ya sincronizados
-
-        $day     = $days[($j - 1) % count($days)];
-
-        $ok = wp_insert_post([
-          'post_type'   => 'tt_pdv',
+      $subroutes = [];
+      foreach ($sub_names as $sub) {
+        $sr_title = $r_title . ' - ' . $sub;
+        $sr_id = wp_insert_post([
+          'post_type'   => 'tt_route',
           'post_status' => 'publish',
-          'post_title'  => $title,
-          'meta_input'  => [
-            '_tt_pdv_route'     => $route_id,
-            '_tt_pdv_code'      => $code,
-            '_tt_pdv_address'   => $address,
-            '_tt_pdv_status'    => $status,
-            '_tt_pdv_day_id'    => $day['id'],
-            '_tt_pdv_day_title' => $day['title'],
-            '_tt_demo'          => 1,
-          ],
+          'post_title'  => $sr_title,
+          'post_parent' => $route_id,
+          'meta_input'  => [ '_tt_demo' => 1 ],
         ]);
-        if ($ok && !is_wp_error($ok)) $pdvs_created++;
+        if ($sr_id && !is_wp_error($sr_id)) $subroutes[] = $sr_id;
+      }
+      if (empty($subroutes)) continue;
+
+      $per_sub = max(1, intval($pdvs_n / count($subroutes)));
+      $counter = 1;
+      foreach ($subroutes as $sr_id) {
+        for ($j=1; $j<=$per_sub; $j++) {
+          $code    = sprintf('%02d-%03d', $i, $counter++);
+          $title   = 'PDV ' . $code;
+          $address = 'Calle ' . rand(1,99) . ', Zona ' . rand(1,24);
+          $status  = (rand(0,100) < 20) ? 'synced' : 'pending';
+
+          $pdv_id = wp_insert_post([
+            'post_type'   => 'tt_pdv',
+            'post_status' => 'publish',
+            'post_title'  => $title,
+            'meta_input'  => [
+              '_tt_pdv_code'    => $code,
+              '_tt_pdv_address' => $address,
+              '_tt_pdv_status'  => $status,
+              '_tt_demo'        => 1,
+            ],
+          ]);
+          if ($pdv_id && !is_wp_error($pdv_id)) {
+            $pdvs_created++;
+            if (class_exists('MB_Relationships_API')) {
+              MB_Relationships_API::add($sr_id, $pdv_id, 'subroute_pdv');
+            }
+          }
+        }
       }
     }
     return ['routes_created'=>$routes_created, 'pdvs_per_route'=>$pdvs_n, 'pdvs_created'=>$pdvs_created, 'user_id'=>$user_id];


### PR DESCRIPTION
## Summary
- support hierarchical `tt_route` post type with slug `ruta`
- use Meta Box relationships to link routes, sub-routes and PDVs
- expose nested PDV catalog and adjust PWA fetch
- register relationships via `MB_Relationships_API` so meta boxes appear in WP admin

## Testing
- `php -l plugin/ttpro-wpapi.php`
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7527f596483278c0a04725aa16865