### PR TITLE
Remove fixed positioning for layout elements

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,32 +1,21 @@
-:root {
-  /* Alturas fijas de layout para header, breadcrumbs y footer (en px) */
-  --app-header-h: 56px;
-  --app-breadcrumb-h: 42px;
-  --app-footer-h: 54px;
-}
-
 /* Fondo general del cuerpo de la app */
 .app-body { background: #f7f9fc; }
 
-/* Barra superior (altura fija) */
-.app-header { height: var(--app-header-h); }
+/* Barra superior */
+.app-header {}
 
-/* Cinta de breadcrumbs (se posiciona debajo del header) */
-.app-bc {
-  top: var(--app-header-h);
-  z-index: 1029;                 /* sobre contenido (similar a Bootstrap navbars) */
-  min-height: var(--app-breadcrumb-h);
-}
+/* Cinta de breadcrumbs */
+.app-bc {}
 
-/* Área principal: agrega padding top/bottom para no tapar header/breadcrumbs/footer */
+/* Área principal: espaciado estándar */
 .app-main {
-  padding-top: calc(var(--app-header-h) + var(--app-breadcrumb-h) + 12px);
-  padding-bottom: calc(var(--app-footer-h) + 12px);
-  min-height: 100vh;             /* pantalla completa (sin contar header/footer) */
+  padding-top: 12px;
+  padding-bottom: 12px;
+  min-height: 100vh;             /* pantalla completa */
 }
 
-/* Barra inferior fija (altura fija) */
-.app-footer { height: var(--app-footer-h); }
+/* Barra inferior */
+.app-footer {}
 
 /* Tarjetas con “sensación táctil”: bordes redondeados + sombra suave */
 .card-tap {

--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
 
 <body class="app-body">
   <!--
-    HEADER FIJO (fixed-top)
+    HEADER
     - Incluye logo/título a la izquierda y acciones rápidas a la derecha.
     - Botones: Ajustes (engranaje) y Cerrar sesión (salir).
   -->
-  <header class="app-header navbar navbar-light bg-white border-bottom fixed-top">
+  <header class="app-header navbar navbar-light bg-white border-bottom">
     <div class="container-fluid align-items-center d-flex justify-content-between">
       <div class="d-flex align-items-center">
         <!-- Logotipo redondeado -->
@@ -63,11 +63,10 @@
   </header>
 
   <!--
-    BREADCRUMBS (sticky-top)
+    BREADCRUMBS
     - Muestra la ruta de navegación; el contenido se inyecta desde main.js en #breadcrumbs
-    - Se posiciona justo debajo del header fijo
   -->
-  <nav class="app-bc border-bottom bg-white sticky-top">
+  <nav class="app-bc border-bottom bg-white">
     <div class="container-fluid">
       <ol class="breadcrumb mb-0 py-2 px-0 bg-white" id="breadcrumbs"></ol>
     </div>
@@ -81,11 +80,11 @@
   <main class="app-main container-fluid" id="app-main" role="main" tabindex="-1"></main>
 
   <!--
-    FOOTER FIJO (fixed-bottom)
+    FOOTER
     - Chips informativos: estado de conexión, pendientes, sincronizados
     - Botón "Sincronizar" para forzar tryProcessQueue()
   -->
-  <footer class="app-footer fixed-bottom border-top bg-white">
+  <footer class="app-footer border-top bg-white">
     <div class="container-fluid py-2">
       <div class="d-flex align-items-center flex-wrap w-100">
         <span class="badge badge-pill badge-success" id="chip-online">Online</span>


### PR DESCRIPTION
## Summary
- Make header, breadcrumbs, and footer scroll with page by dropping fixed/sticky classes
- Simplify layout styles to remove fixed height variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b88f7837288327bceaf58527c03f46