### PR TITLE
Move sync button below pending list

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1233,11 +1233,9 @@
 
     $c.html(
       '<div class="container py-3">' +
-        '<div class="d-flex align-items-center mb-2">' +
-          '<h5 class="m-0">Pendientes</h5>' +
-          '<button class="btn btn-primary ml-auto" id="btn-sync">Sincronizar</button>' +
-        '</div>' +
-        '<div id="list" class="list-group"></div>' +
+        '<h5 class="mb-2">Pendientes</h5>' +
+        '<div id="list" class="list-group mb-3"></div>' +
+        '<button class="btn btn-primary btn-block" id="btn-sync">Sincronizar</button>' +
       '</div>'
     );
 


### PR DESCRIPTION
## Summary
- Place the `Sincronizar` button beneath the pending items list and make it full width

## Testing
- `npm test` (fails: ENOENT, could not read package.json)
- `npm run lint` (fails: ENOENT, could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b8c63ceb8c8327a5e2136d2745bbd0