### PR TITLE
feat: show overall progress for routes

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -547,10 +547,23 @@
     const routes = (store.routesAll || [])
       .slice()
       .sort((a, b) => (a.title || '').localeCompare(b.title || ''));
+    const allPdvs = [];
+    routes.forEach((r) => {
+      allPdvs.push(...pdvsFromRoute(r));
+    });
+    const overall = summarizeProgress(allPdvs);
 
     $c.html(
       '<div class="container py-3">' +
         '<h5 class="mb-3">Rutas</h5>' +
+        '<div class="mb-3">' +
+          '<div class="d-flex align-items-center mb-1">' +
+            '<small class="text-muted mr-2">Progreso</small>' +
+            '<span class="badge badge-light">' + overall.done + '/' + overall.total + '</span>' +
+            '<span class="ml-auto small text-muted">' + overall.pct + '%</span>' +
+          '</div>' +
+          '<div class="progress thin"><div class="progress-bar" style="width:' + overall.pct + '%"></div></div>' +
+        '</div>' +
         '<div class="list-group" id="route-list"></div>' +
       '</div>'
     );


### PR DESCRIPTION
## Summary
- display overall completion stats across all assigned routes at top of routes screen

## Testing
- `npm test` (fails: enoent Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bcb5bc1cec8327b9b21f3fa52aea95