### PR TITLE
Persist user session between PWA restarts

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -114,6 +114,13 @@
       $c.html('<div class="alert alert-danger m-3">Error al renderizar: ' + (e.message || e) + '</div>');
       console.error(e);
     }
+
+    // Guarda la última ruta visitada para restaurarla al reiniciar la app.
+    if (path !== '/') {
+      localStorage.setItem('lastPath', location.hash);
+    } else {
+      localStorage.removeItem('lastPath');
+    }
   }
 
   // Re-render cuando cambia el hash
@@ -362,7 +369,16 @@
     await loadCached();
     setOnlineUI();
     await refreshCounts();
-    navigateTo();
+
+    // Si hay sesión previa, restaurar la última ruta visitada o ir a rutas.
+    const lastPath = localStorage.getItem('lastPath');
+    if (hasSession() && lastPath) {
+      navigateTo(lastPath);
+    } else if (hasSession() && (!location.hash || location.hash === '#/')) {
+      navigateTo('#/routes');
+    } else {
+      navigateTo();
+    }
   })();
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- save last visited route in local storage
- restore saved route when starting the PWA to keep session active

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c322721083279075aa0e1c6ecf99