### PR TITLE
Add numeric field type

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1061,6 +1061,13 @@
           .append('<div class="form-step-title mb-2">' + f.label + '</div>')
           .append($ta);
       }
+      if (f.type === 'number') {
+        const $num = $('<input type="number" inputmode="numeric" pattern="[0-9]*" class="form-control">').val(val || '');
+        $num.on('input', () => onChange($num.val()));
+        return $('<div class="mb-3"></div>')
+          .append('<div class="form-step-title mb-2">' + f.label + '</div>')
+          .append($num);
+      }
       const $in = $('<input type="text" class="form-control">').val(val || '');
       $in.on('input', () => onChange($in.val()));
       return $('<div class="mb-3"></div>')

--- a/plugin/ttpro-wpapi.php
+++ b/plugin/ttpro-wpapi.php
@@ -214,6 +214,7 @@ class TTPro_Api {
                 'text'     => 'Text',
                 'textarea' => 'Textarea',
                 'radio'    => 'Radio',
+                'number'   => 'Number',
                 'photo'    => 'Photo',
                 'geo'      => 'Geo',
               ],


### PR DESCRIPTION
## Summary
- allow catalog questions to use number field type
- render number fields with numeric-only input in PWA form

## Testing
- `node --check js/main.js`
- `php -l plugin/ttpro-wpapi.php`


------
https://chatgpt.com/codex/tasks/task_e_68c10876bf8483278da5706bd0c469dc