### PR TITLE
Clear cache on login

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -332,6 +332,21 @@
   }
 
   /**
+   * Elimina todas las entradas de Cache Storage de la aplicación.
+   * @param {boolean} [alertUser=false] Muestra un alert al finalizar
+   */
+  async function clearCacheStorage(alertUser = false) {
+    if (window.caches) {
+      const ks = await caches.keys();
+      for (const k of ks) await caches.delete(k);
+    }
+
+    if (alertUser) {
+      alert('Caché limpiada. Recarga la app.');
+    }
+  }
+
+  /**
    * Determina si hay sesión activa (JWT o flag local).
    */
   function hasSession() {
@@ -522,6 +537,7 @@
         localStorage.setItem('jwt', j.token);
         localStorage.setItem('sessionActive', '1');
 
+        await clearCacheStorage();
         await bootstrapData();
         await loadCached();
         updateAuthIcon();
@@ -1395,11 +1411,7 @@
 
     // Limpiar caches de Cache Storage
     $('#btn-clear-cache').on('click', async function () {
-      if (window.caches) {
-        const ks = await caches.keys();
-        for (const k of ks) await caches.delete(k);
-      }
-      alert('Caché limpiada. Recarga la app.');
+      await clearCacheStorage(true);
     });
 
     // Ir a inicio dependiendo de si hay sesión


### PR DESCRIPTION
## Summary
- refactor cache clearing into reusable helper
- clear caches automatically after successful login before bootstrap
- reuse cache clearing helper in settings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c10e906bfc832799ff78e300e62f4b