### PR TITLE
fix: preserve camera events when navigating form

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1122,7 +1122,10 @@
       if (step >= seq.length) step = seq.length - 1;
 
       const f = seq[step];
-      const $b = $('#form-body').empty();
+      const $b = $('#form-body');
+      // Preservamos los eventos del widget de cámara al cambiar de paso
+      cam.$root.detach();
+      $b.empty();
 
       if (f.type === 'photo') {
         $b.append(cam.$root);


### PR DESCRIPTION
## Summary
- keep camera widget events when changing steps by detaching before clearing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c114622c6c832789bf2b342373b71f