### PR TITLE
chore: bump version to 5.9.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <title>TT Censo 2025</title>
 
   <!-- Manifest PWA: nombre, íconos, scope y comportamiento de instalación -->
-  <link rel="manifest" href="./manifest.webmanifest?v=5.9.0">
+  <link rel="manifest" href="./manifest.webmanifest?v=5.9.1">
 
   <!-- Favicon/ícono base (también útil para splash en algunas plataformas) -->
   <link rel="icon" href="./assets/icons/icon-192.png" sizes="192x192">
@@ -24,7 +24,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
   <!-- Estilos propios de la app (versionados por querystring) -->
-  <link href="./css/app.css?v=5.9.0" rel="stylesheet">
+  <link href="./css/app.css?v=5.9.1" rel="stylesheet">
 
   <!-- Evita cachear este HTML (útil durante desarrollo/QA) -->
   <meta http-equiv="Cache-Control" content="no-store, max-age=0, must-revalidate">
@@ -98,7 +98,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 
   <!-- Código de la app (versionado por querystring) -->
-  <script src="./js/main.js?v=5.9.0"></script>
+  <script src="./js/main.js?v=5.9.1"></script>
 
   <!-- Registro de Service Worker
        - Se hace en 'load' para no bloquear el first paint
@@ -107,7 +107,7 @@
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () =>
-        navigator.serviceWorker.register('./sw.js?v=5.9.0', { scope: './' }).catch(() => {})
+        navigator.serviceWorker.register('./sw.js?v=5.9.1', { scope: './' }).catch(() => {})
       );
     }
   </script>

--- a/js/main.js
+++ b/js/main.js
@@ -17,7 +17,7 @@
   // Constantes base de la aplicación
   // ---------------------------------------------------------------------------
   const BRAND = 'TT Censo 2025';
-  const APP_VERSION = '5.9.0';
+  const APP_VERSION = '5.9.1';
   const API_BASE = 'https://todoterreno.prueba.in';
   const IDBVER = 7; // Versión del esquema de IndexedDB
 

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
-// SW — 5.9.0
-const CACHE = 'ttpro-5.9.0';
+// SW — 5.9.1
+const CACHE = 'ttpro-5.9.1';
 const PRECACHE = [
-  './','./index.html','./manifest.webmanifest?v=5.9.0',
+  './','./index.html','./manifest.webmanifest?v=5.9.1',
   './assets/icons/icon-192.png','./assets/icons/icon-512.png',
-  './js/main.js?v=5.9.0','./css/app.css?v=5.9.0','./sw-reset.html',
+  './js/main.js?v=5.9.1','./css/app.css?v=5.9.1','./sw-reset.html',
   'https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css',
   'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js',
   'https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js'


### PR DESCRIPTION
## Summary
- update cached asset versions to 5.9.1

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dc9ea0f88327a8ad17d1aa41660d