### PR TITLE
Add post-based question field type

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1139,7 +1139,7 @@
     }
 
     function renderField(f, val, onChange) {
-      if (f.type === 'radio' || f.type === 'checkbox') {
+      if (f.type === 'radio' || f.type === 'checkbox' || f.type === 'post') {
         return renderFieldCard(f, val, onChange);
       }
       if (f.type === 'textarea') {


### PR DESCRIPTION
## Summary
- add a "post" question type to the settings page with a post type selector
- populate post-driven questions from queried posts with filters to customize results
- render post-driven questions as radio groups inside the PWA form

## Testing
- php -l plugin/ttpro-wpapi.php

------
https://chatgpt.com/codex/tasks/task_e_68c91d0370e88327a95cee0e3862a194