### PR TITLE
Add delete action for PDVs

### DIFF
--- a/plugin/assets/pdv-table.js
+++ b/plugin/assets/pdv-table.js
@@ -104,6 +104,41 @@
         });
       });
     }
+
+    if (cfg.deleteUrl){
+      $table.on('click', '.ttpro-pdv-delete-btn', function(ev){
+        ev.preventDefault();
+
+        var $btn = $(this);
+        var pdvId = $btn.data('pdv-id');
+        if (!pdvId){
+          return;
+        }
+
+        if (!window.confirm('¿Deseas eliminar este punto de venta? Se enviará a la papelera.')){
+          return;
+        }
+
+        $btn.prop('disabled', true).addClass('ttpro-pdv-delete-btn--loading');
+
+        $.ajax({
+          url: cfg.deleteUrl,
+          method: 'POST',
+          headers: ajaxHeaders,
+          data: { pdv_id: pdvId }
+        }).done(function(){
+          dt.ajax.reload(null, false);
+        }).fail(function(xhr){
+          var message = 'No se pudo eliminar el punto de venta.';
+          if (xhr && xhr.responseJSON && xhr.responseJSON.message){
+            message = xhr.responseJSON.message;
+          }
+          window.alert(message);
+        }).always(function(){
+          $btn.prop('disabled', false).removeClass('ttpro-pdv-delete-btn--loading');
+        });
+      });
+    }
   }
 
   $(function(){


### PR DESCRIPTION
## Summary
- add a new "Eliminar" column/button to the PDV table for authorized users
- expose a REST endpoint that trashes PDVs through wp_trash_post
- wire up the frontend table script to call the new endpoint and refresh the table

## Testing
- php -l plugin/ttpro-wpapi.php

------
https://chatgpt.com/codex/tasks/task_e_68d474ad650c8327b259aac3c4448399