### PR TITLE
Add PDV editor shortcode and table edit links

### DIFF
--- a/plugin/assets/pdv-editor.css
+++ b/plugin/assets/pdv-editor.css
@@ -1,0 +1,109 @@
+.ttpro-pdv-editor {
+  background: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+.ttpro-editor-notice {
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  border-radius: 6px;
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.ttpro-editor-notice--error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.ttpro-editor-notice--success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.ttpro-pdv-editor-field {
+  margin-bottom: 20px;
+}
+
+.ttpro-field-hidden {
+  display: none;
+}
+
+.ttpro-field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.ttpro-required {
+  color: #dc2626;
+}
+
+.ttpro-input {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 4px;
+  border: 1px solid #d1d5db;
+  font-size: 14px;
+}
+
+.ttpro-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+
+.ttpro-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.ttpro-instruction {
+  margin-top: 8px;
+}
+
+.ttpro-instruction img {
+  max-width: 100%;
+  border-radius: 4px;
+  border: 1px solid #e5e7eb;
+}
+
+.ttpro-geo-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.ttpro-photo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ttpro-photo-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+}
+
+.ttpro-current-photo {
+  color: #4b5563;
+}
+
+.ttpro-remove-photo input {
+  margin-right: 4px;
+}
+
+.ttpro-editor-actions {
+  margin-top: 24px;
+}
+
+.ttpro-editor-actions .button {
+  padding: 10px 20px;
+  font-size: 15px;
+}

--- a/plugin/assets/pdv-editor.js
+++ b/plugin/assets/pdv-editor.js
@@ -1,0 +1,119 @@
+(function($){
+  function parseConditions(raw){
+    if (!raw){
+      return [];
+    }
+    try {
+      var parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)){
+        return parsed;
+      }
+      if (parsed && typeof parsed === 'object'){
+        return [parsed];
+      }
+    } catch (e){}
+    return [];
+  }
+
+  function fieldValue($form, fieldId){
+    var $inputs = $form.find('[name^="ttpro_answers[' + fieldId + ']"], [name^="ttpro_geo[' + fieldId + ']"], [name^="ttpro_photo[' + fieldId + ']"]');
+    if (!$inputs.length){
+      return [];
+    }
+
+    var values = [];
+
+    $inputs.each(function(){
+      var $el = $(this);
+      var type = ($el.attr('type') || '').toLowerCase();
+
+      if (type === 'checkbox'){
+        if ($el.prop('checked')){
+          values.push($el.val());
+        }
+      } else if (type === 'radio'){
+        if ($el.prop('checked')){
+          values.push($el.val());
+        }
+      } else if ($el.is('select')){
+        var val = $el.val();
+        if (Array.isArray(val)){
+          values = values.concat(val);
+        } else if (val !== null && val !== undefined && val !== ''){
+          values.push(val);
+        }
+      } else if ($el.is('input') || $el.is('textarea')){
+        var v = $el.val();
+        if (v !== null && v !== undefined && String(v).trim() !== ''){
+          values.push(String(v).trim());
+        }
+      }
+    });
+
+    return values;
+  }
+
+  function evaluateField($field, $form){
+    var raw = $field.attr('data-show-if');
+    if (!raw){
+      $field.removeClass('ttpro-field-hidden');
+      return;
+    }
+
+    var conditions = parseConditions(raw);
+    if (!conditions.length){
+      $field.removeClass('ttpro-field-hidden');
+      return;
+    }
+
+    var visible = conditions.every(function(cond){
+      if (!cond || !cond.id){
+        return true;
+      }
+      var expected = [];
+      if (Array.isArray(cond.value)){
+        expected = cond.value.map(function(v){ return String(v); });
+      } else if (cond.value !== undefined && cond.value !== null){
+        expected = [String(cond.value)];
+      }
+      if (!expected.length){
+        return false;
+      }
+      var actual = fieldValue($form, cond.id).map(function(v){ return String(v); });
+      if (!actual.length){
+        return false;
+      }
+      for (var i = 0; i < expected.length; i++){
+        if (actual.indexOf(expected[i]) !== -1){
+          return true;
+        }
+      }
+      return false;
+    });
+
+    if (visible){
+      $field.removeClass('ttpro-field-hidden');
+    } else {
+      $field.addClass('ttpro-field-hidden');
+    }
+  }
+
+  function initForm($form){
+    var $fields = $form.find('.ttpro-pdv-editor-field');
+
+    function refresh(){
+      $fields.each(function(){
+        evaluateField($(this), $form);
+      });
+    }
+
+    $form.on('change input', 'input, select, textarea', refresh);
+    refresh();
+  }
+
+  $(function(){
+    $('.ttpro-pdv-editor-form').each(function(){
+      initForm($(this));
+    });
+  });
+})(jQuery);


### PR DESCRIPTION
## Summary
- add an Edit column to the PDV DataTable so users can jump to each PDV single page
- create a `[ttpro_pdv_editor]` shortcode that renders a form mirroring the catalog questions and saves answers to post meta
- include frontend assets for conditional field visibility, styling, and photo handling in the editor

## Testing
- php -l plugin/ttpro-wpapi.php

------
https://chatgpt.com/codex/tasks/task_e_68d47b1dea1c8327bd43b4d4f45d97d9