### PR TITLE
Implement step-by-step PDV editor interface

### DIFF
--- a/plugin/assets/pdv-editor.css
+++ b/plugin/assets/pdv-editor.css
@@ -107,3 +107,114 @@
   padding: 10px 20px;
   font-size: 15px;
 }
+
+.ttpro-step-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.ttpro-step-prev {
+  background: transparent;
+  border: none;
+  color: #2563eb;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 0;
+}
+
+.ttpro-step-prev:hover {
+  color: #1d4ed8;
+}
+
+.ttpro-step-prev[disabled] {
+  color: #9ca3af;
+  cursor: default;
+}
+
+.ttpro-step-indicator {
+  background: #2563eb;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 4px 12px;
+}
+
+.ttpro-step-progress {
+  height: 6px;
+  border-radius: 999px;
+  background: #e5e7eb;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.ttpro-step-progress-bar {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #2563eb, #4f46e5);
+  transition: width 0.25s ease;
+}
+
+.ttpro-step-body {
+  min-height: 240px;
+}
+
+.ttpro-pdv-editor-field.ttpro-step-hidden-step {
+  display: none;
+}
+
+.ttpro-pdv-editor-field.ttpro-step-active {
+  display: block;
+}
+
+.ttpro-step-actions {
+  margin-top: 24px;
+  position: sticky;
+  bottom: 0;
+  background: linear-gradient(180deg, rgba(255,255,255,0) 0%, #fff 40%);
+  padding-top: 16px;
+}
+
+.ttpro-step-next {
+  width: 100%;
+  background: #2563eb;
+  border: none;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+  padding: 12px 18px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.18);
+}
+
+.ttpro-step-next:hover {
+  background: #1d4ed8;
+}
+
+.ttpro-step-next:active {
+  transform: translateY(1px);
+}
+
+.ttpro-step-next[disabled] {
+  background: #93c5fd;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+@media (max-width: 600px) {
+  .ttpro-pdv-editor {
+    padding: 20px 16px;
+  }
+
+  .ttpro-step-body {
+    min-height: 200px;
+  }
+}

--- a/plugin/assets/pdv-editor.js
+++ b/plugin/assets/pdv-editor.js
@@ -16,39 +16,53 @@
   }
 
   function fieldValue($form, fieldId){
-    var $inputs = $form.find('[name^="ttpro_answers[' + fieldId + ']"], [name^="ttpro_geo[' + fieldId + ']"], [name^="ttpro_photo[' + fieldId + ']"]');
-    if (!$inputs.length){
-      return [];
-    }
-
+    var selector = '[name^="ttpro_answers[' + fieldId + ']"], [name^="ttpro_geo[' + fieldId + ']"], [name^="ttpro_photo[' + fieldId + ']"]';
+    var $inputs = $form.find(selector);
     var values = [];
 
-    $inputs.each(function(){
-      var $el = $(this);
-      var type = ($el.attr('type') || '').toLowerCase();
+    if ($inputs.length){
+      $inputs.each(function(){
+        var $el = $(this);
+        var type = ($el.attr('type') || '').toLowerCase();
 
-      if (type === 'checkbox'){
-        if ($el.prop('checked')){
-          values.push($el.val());
+        if (type === 'checkbox'){
+          if ($el.prop('checked')){
+            values.push($el.val());
+          }
+        } else if (type === 'radio'){
+          if ($el.prop('checked')){
+            values.push($el.val());
+          }
+        } else if ($el.is('select')){
+          var val = $el.val();
+          if (Array.isArray(val)){
+            values = values.concat(val);
+          } else if (val !== null && val !== undefined && val !== ''){
+            values.push(val);
+          }
+        } else if ($el.is('input') || $el.is('textarea')){
+          var v = $el.val();
+          if (v !== null && v !== undefined && String(v).trim() !== ''){
+            values.push(String(v).trim());
+          }
         }
-      } else if (type === 'radio'){
-        if ($el.prop('checked')){
-          values.push($el.val());
+      });
+    }
+
+    var $field = $form.find('.ttpro-pdv-editor-field[data-field-id="' + fieldId + '"]');
+    if ($field.length){
+      var typeAttr = ($field.attr('data-field-type') || '').toLowerCase();
+      if (typeAttr === 'photo'){
+        var $remove = $field.find('[name^="ttpro_remove_photo[' + fieldId + ']"]');
+        if ($remove.filter(':checked').length){
+          return [];
         }
-      } else if ($el.is('select')){
-        var val = $el.val();
-        if (Array.isArray(val)){
-          values = values.concat(val);
-        } else if (val !== null && val !== undefined && val !== ''){
-          values.push(val);
-        }
-      } else if ($el.is('input') || $el.is('textarea')){
-        var v = $el.val();
-        if (v !== null && v !== undefined && String(v).trim() !== ''){
-          values.push(String(v).trim());
+        var $existing = $field.find('[name^="ttpro_existing_photo[' + fieldId + ']"]');
+        if ($existing.length && String($existing.val()) === '1'){
+          values.push('existing');
         }
       }
-    });
+    }
 
     return values;
   }
@@ -98,16 +112,213 @@
     }
   }
 
+  function isFieldValid($field){
+    if (!$field || !$field.length){
+      return true;
+    }
+    if ($field.hasClass('ttpro-field-hidden')){
+      return true;
+    }
+
+    var required = String($field.attr('data-required') || '') === '1';
+    if (!required){
+      return true;
+    }
+
+    var type = ($field.attr('data-field-type') || '').toLowerCase();
+
+    if (type === 'checkbox'){
+      return $field.find('input[type="checkbox"]:checked').length > 0;
+    }
+    if (type === 'radio' || type === 'post'){
+      return $field.find('input[type="radio"]:checked').length > 0;
+    }
+    if (type === 'geo'){
+      var lat = $field.find('[name$="[lat]"]').val();
+      var lng = $field.find('[name$="[lng]"]').val();
+      return !!(lat && String(lat).trim() !== '' && lng && String(lng).trim() !== '');
+    }
+    if (type === 'photo'){
+      var fileInput = $field.find('input[type="file"]').get(0);
+      var hasFile = !!(fileInput && fileInput.files && fileInput.files.length);
+      if (hasFile){
+        return true;
+      }
+      var hasExisting = String($field.find('[name^="ttpro_existing_photo"]').val() || '') === '1';
+      var removeChecked = $field.find('[name^="ttpro_remove_photo"]').filter(':checked').length > 0;
+      return hasExisting && !removeChecked;
+    }
+
+    var $controls = $field.find('input:not([type="hidden"]), textarea, select');
+    if (!$controls.length){
+      return true;
+    }
+
+    var valid = true;
+    $controls.each(function(){
+      if (!valid){
+        return false;
+      }
+      var $el = $(this);
+      if ($el.is(':hidden') && !$el.is('select')){
+        return true;
+      }
+      var val = $el.val();
+      if (val === null || val === undefined || String(val).trim() === ''){
+        valid = false;
+      }
+    });
+
+    return valid;
+  }
+
   function initForm($form){
     var $fields = $form.find('.ttpro-pdv-editor-field');
+    if (!$fields.length){
+      return;
+    }
 
-    function refresh(){
+    var state = { step: 0 };
+    var $stepIndicator = $form.find('.ttpro-step-indicator');
+    var $progressBar = $form.find('.ttpro-step-progress-bar');
+    var $progress = $form.find('.ttpro-step-progress');
+    var $nextBtn = $form.find('.ttpro-step-next');
+    var $prevBtn = $form.find('.ttpro-step-prev');
+
+    var defaultNextLabel = $nextBtn.data('default-label') || $nextBtn.text();
+    var finalNextLabel = $nextBtn.data('final-label') || defaultNextLabel;
+
+    function getVisibleFields(){
+      return $fields.filter(function(){
+        return !$(this).hasClass('ttpro-field-hidden');
+      });
+    }
+
+    function clampStep(){
+      var total = getVisibleFields().length;
+      if (!total){
+        state.step = 0;
+        return;
+      }
+      if (state.step >= total){
+        state.step = total - 1;
+      }
+      if (state.step < 0){
+        state.step = 0;
+      }
+    }
+
+    function focusCurrent($current){
+      if (!$current || !$current.length){
+        return;
+      }
+      setTimeout(function(){
+        var $focusable = $current.find('input:not([type="hidden"]), textarea, select').filter(function(){
+          var $el = $(this);
+          if ($el.is(':disabled')){
+            return false;
+          }
+          if ($el.is('input[type="radio"], input[type="checkbox"]')){
+            return $el.is(':visible');
+          }
+          return $el.is(':visible');
+        }).first();
+        if ($focusable.length){
+          $focusable.trigger('focus');
+        }
+      }, 10);
+    }
+
+    function updateUI(){
+      clampStep();
+      var $visible = getVisibleFields();
+      var total = $visible.length;
+
+      $fields.removeClass('ttpro-step-active ttpro-step-hidden-step');
+
+      if (!total){
+        $stepIndicator.text('0/0');
+        $progressBar.css('width', '0%');
+        $progress.attr('aria-valuenow', 0);
+        $nextBtn.prop('disabled', true);
+        $prevBtn.prop('disabled', true);
+        return;
+      }
+
+      var $current = $visible.eq(state.step);
+      $visible.addClass('ttpro-step-hidden-step');
+      if ($current.length){
+        $current.removeClass('ttpro-step-hidden-step').addClass('ttpro-step-active');
+      }
+
+      var isLast = state.step === total - 1;
+      var pct = total > 1 ? Math.round((state.step / (total - 1)) * 100) : 100;
+      if (!isFinite(pct)){
+        pct = 0;
+      }
+
+      $stepIndicator.text((state.step + 1) + '/' + total);
+      $progressBar.css('width', pct + '%');
+      $progress.attr('aria-valuenow', pct);
+      $nextBtn.text(isLast ? finalNextLabel : defaultNextLabel);
+      $prevBtn.prop('disabled', state.step === 0);
+
+      var canAdvance = isFieldValid($current);
+      $nextBtn.prop('disabled', !canAdvance);
+
+      focusCurrent($current);
+    }
+
+    function applyConditions(){
       $fields.each(function(){
         evaluateField($(this), $form);
       });
     }
 
-    $form.on('change input', 'input, select, textarea', refresh);
+    function refresh(){
+      applyConditions();
+      updateUI();
+    }
+
+    $form.on('change input', 'input, select, textarea', function(){
+      refresh();
+    });
+
+    $nextBtn.on('click', function(e){
+      e.preventDefault();
+      var $visible = getVisibleFields();
+      if (!$visible.length){
+        return;
+      }
+      var $current = $visible.eq(state.step);
+      if (!isFieldValid($current)){
+        focusCurrent($current);
+        return;
+      }
+      var isLast = state.step >= ($visible.length - 1);
+      if (isLast){
+        var formEl = $form.get(0);
+        if (formEl){
+          if (typeof formEl.requestSubmit === 'function'){
+            formEl.requestSubmit();
+          } else {
+            formEl.submit();
+          }
+        }
+        return;
+      }
+      state.step += 1;
+      updateUI();
+    });
+
+    $prevBtn.on('click', function(e){
+      e.preventDefault();
+      if (state.step > 0){
+        state.step -= 1;
+        updateUI();
+      }
+    });
+
     refresh();
   }
 

--- a/plugin/ttpro-wpapi.php
+++ b/plugin/ttpro-wpapi.php
@@ -1736,7 +1736,7 @@ class TTPro_Api {
       'ttpro-pdv-editor',
       plugins_url('assets/pdv-editor.css', __FILE__),
       [],
-      '1.0.0'
+      '1.1.0'
     );
     wp_enqueue_style('ttpro-pdv-editor');
 
@@ -1744,7 +1744,7 @@ class TTPro_Api {
       'ttpro-pdv-editor',
       plugins_url('assets/pdv-editor.js', __FILE__),
       ['jquery'],
-      '1.0.0',
+      '1.1.0',
       true
     );
     wp_enqueue_script('ttpro-pdv-editor');
@@ -1867,6 +1867,7 @@ class TTPro_Api {
       'class' => 'ttpro-pdv-editor-field',
       'data-field-id' => esc_attr($id),
       'data-field-type' => esc_attr($type),
+      'data-required' => $required ? '1' : '0',
     ];
 
     if (!empty($conditions)) {
@@ -2203,30 +2204,53 @@ class TTPro_Api {
       $notice .= '<div class="ttpro-editor-notice ttpro-editor-notice--error"><ul>' . $error_items . '</ul></div>';
     }
 
+    $next_label = __('Siguiente', 'ttpro');
+    $final_label = __('Guardar cambios', 'ttpro');
+    $prev_label = __('Anterior', 'ttpro');
+
     ob_start();
     ?>
     <div class="ttpro-pdv-editor">
       <?php echo $notice; ?>
       <form class="ttpro-pdv-editor-form" method="post" enctype="multipart/form-data">
         <?php wp_nonce_field('ttpro_pdv_editor_' . $pdv_id, 'ttpro_pdv_editor_nonce'); ?>
-        <?php foreach ($fields as $field):
-          $id = isset($field['id']) ? $field['id'] : '';
-          if ($id === '') {
-            continue;
-          }
-          $value = isset($existing_answers[$id]) ? $existing_answers[$id] : '';
-          $has_photo = false;
-          if (isset($field['type']) && $field['type'] === 'photo') {
-            $has_photo = ($value === '1' || $value === 1 || (is_array($value) && !empty($value)));
-            if (!$has_photo) {
-              $thumb_id = get_post_thumbnail_id($pdv_id);
-              $has_photo = $thumb_id ? true : false;
+        <noscript>
+          <div class="ttpro-editor-notice ttpro-editor-notice--error">
+            <?php esc_html_e('Este formulario requiere JavaScript para completar las respuestas.', 'ttpro'); ?>
+          </div>
+        </noscript>
+        <div class="ttpro-step-header">
+          <button type="button" class="ttpro-step-prev" disabled>&larr; <?php echo esc_html($prev_label); ?></button>
+          <span class="ttpro-step-indicator" aria-live="polite">1/1</span>
+        </div>
+        <div class="ttpro-step-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+          <div class="ttpro-step-progress-bar"></div>
+        </div>
+        <div class="ttpro-step-body">
+          <?php foreach ($fields as $field):
+            $id = isset($field['id']) ? $field['id'] : '';
+            if ($id === '') {
+              continue;
             }
-          }
-          echo $this->render_editor_field($field, $value, $has_photo);
-        endforeach; ?>
-        <div class="ttpro-editor-actions">
-          <button type="submit" class="button button-primary"><?php esc_html_e('Guardar cambios', 'ttpro'); ?></button>
+            $value = isset($existing_answers[$id]) ? $existing_answers[$id] : '';
+            $has_photo = false;
+            if (isset($field['type']) && $field['type'] === 'photo') {
+              $has_photo = ($value === '1' || $value === 1 || (is_array($value) && !empty($value)));
+              if (!$has_photo) {
+                $thumb_id = get_post_thumbnail_id($pdv_id);
+                $has_photo = $thumb_id ? true : false;
+              }
+            }
+            echo $this->render_editor_field($field, $value, $has_photo);
+          endforeach; ?>
+        </div>
+        <div class="ttpro-step-actions">
+          <button
+            type="button"
+            class="ttpro-step-next"
+            data-default-label="<?php echo esc_attr($next_label); ?>"
+            data-final-label="<?php echo esc_attr($final_label); ?>"
+          ><?php echo esc_html($next_label); ?></button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- rework the PDV editor markup to present questions one by one with progress and navigation controls similar to the PWA
- add styling for the new stepper layout including progress bar, sticky action area, and responsive tweaks
- update the PDV editor JavaScript to reuse conditional logic while managing step transitions, validation, and submission

## Testing
- php -l plugin/ttpro-wpapi.php

------
https://chatgpt.com/codex/tasks/task_e_68d483f35b7083279a8d207875f14fcf