### PR TITLE
Normalize conditional logic metadata for PDV editor

### DIFF
--- a/plugin/assets/pdv-editor.css
+++ b/plugin/assets/pdv-editor.css
@@ -1,16 +1,18 @@
 .ttpro-pdv-editor {
-  background: #fff;
+  background: #ffffff;
+  border-radius: 10px;
   padding: 24px;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
 }
 
 .ttpro-editor-notice {
-  margin-bottom: 16px;
-  padding: 12px 16px;
-  border-radius: 6px;
-  background: #f3f4f6;
-  color: #111827;
+  margin-bottom: 20px;
+  padding: 14px 18px;
+  border-radius: 8px;
+  font-size: 14px;
+  line-height: 1.45;
+  background: #f8fafc;
+  color: #1f2937;
 }
 
 .ttpro-editor-notice--error {
@@ -23,109 +25,32 @@
   color: #166534;
 }
 
-.ttpro-pdv-editor-field {
-  margin-bottom: 20px;
-}
-
-.ttpro-field-hidden {
-  display: none;
-}
-
-.ttpro-field-label {
-  display: block;
-  font-weight: 600;
-  margin-bottom: 6px;
-}
-
-.ttpro-required {
-  color: #dc2626;
-}
-
-.ttpro-input {
-  width: 100%;
-  padding: 8px 10px;
-  border-radius: 4px;
-  border: 1px solid #d1d5db;
-  font-size: 14px;
-}
-
-.ttpro-options {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 16px;
-}
-
-.ttpro-option {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 14px;
-}
-
-.ttpro-instruction {
-  margin-top: 8px;
-}
-
-.ttpro-instruction img {
-  max-width: 100%;
-  border-radius: 4px;
-  border: 1px solid #e5e7eb;
-}
-
-.ttpro-geo-fields {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 12px;
-}
-
-.ttpro-photo-field {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.ttpro-photo-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  font-size: 13px;
-}
-
-.ttpro-current-photo {
-  color: #4b5563;
-}
-
-.ttpro-remove-photo input {
-  margin-right: 4px;
-}
-
-.ttpro-editor-actions {
-  margin-top: 24px;
-}
-
-.ttpro-editor-actions .button {
-  padding: 10px 20px;
-  font-size: 15px;
-}
-
 .ttpro-step-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  margin-bottom: 18px;
+  gap: 12px;
 }
 
 .ttpro-step-prev {
-  background: transparent;
+  appearance: none;
   border: none;
-  color: #2563eb;
-  cursor: pointer;
+  background: transparent;
+  padding: 0;
   display: inline-flex;
   align-items: center;
   gap: 6px;
   font-size: 14px;
   font-weight: 500;
-  padding: 0;
+  color: #2563eb;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.ttpro-step-prev svg {
+  width: 16px;
+  height: 16px;
 }
 
 .ttpro-step-prev:hover {
@@ -138,31 +63,48 @@
 }
 
 .ttpro-step-indicator {
-  background: #2563eb;
-  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
   font-size: 13px;
   font-weight: 600;
-  border-radius: 999px;
-  padding: 4px 12px;
+  color: #ffffff;
+  background: linear-gradient(120deg, #2563eb, #4f46e5);
 }
 
 .ttpro-step-progress {
+  position: relative;
+  width: 100%;
   height: 6px;
   border-radius: 999px;
   background: #e5e7eb;
   overflow: hidden;
-  margin-bottom: 20px;
+  margin-bottom: 24px;
 }
 
 .ttpro-step-progress-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
   height: 100%;
   width: 0%;
-  background: linear-gradient(90deg, #2563eb, #4f46e5);
+  border-radius: inherit;
+  background: linear-gradient(120deg, #2563eb, #4f46e5);
   transition: width 0.25s ease;
 }
 
 .ttpro-step-body {
   min-height: 240px;
+}
+
+.ttpro-pdv-editor-field {
+  margin-bottom: 24px;
+}
+
+.ttpro-pdv-editor-field:last-child {
+  margin-bottom: 0;
 }
 
 .ttpro-pdv-editor-field.ttpro-step-hidden-step {
@@ -173,30 +115,127 @@
   display: block;
 }
 
+.ttpro-field-hidden {
+  display: none !important;
+}
+
+.ttpro-field-label {
+  display: block;
+  font-size: 15px;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 8px;
+}
+
+.ttpro-required {
+  color: #dc2626;
+}
+
+.ttpro-input,
+.ttpro-pdv-editor-field input[type="text"],
+.ttpro-pdv-editor-field input[type="number"],
+.ttpro-pdv-editor-field input[type="email"],
+.ttpro-pdv-editor-field input[type="tel"],
+.ttpro-pdv-editor-field select,
+.ttpro-pdv-editor-field textarea {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  padding: 10px 12px;
+  font-size: 15px;
+  line-height: 1.45;
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ttpro-input:focus,
+.ttpro-pdv-editor-field input[type="text"]:focus,
+.ttpro-pdv-editor-field input[type="number"]:focus,
+.ttpro-pdv-editor-field input[type="email"]:focus,
+.ttpro-pdv-editor-field input[type="tel"]:focus,
+.ttpro-pdv-editor-field select:focus,
+.ttpro-pdv-editor-field textarea:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  outline: none;
+}
+
+.ttpro-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.ttpro-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #1f2937;
+}
+
+.ttpro-instruction {
+  margin-top: 10px;
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.ttpro-instruction img {
+  display: block;
+  max-width: 100%;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+}
+
+.ttpro-geo-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.ttpro-photo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ttpro-photo-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: #4b5563;
+}
+
+.ttpro-current-photo {
+  font-size: 13px;
+  color: #475569;
+}
+
 .ttpro-step-actions {
-  margin-top: 24px;
+  margin-top: 28px;
   position: sticky;
   bottom: 0;
-  background: linear-gradient(180deg, rgba(255,255,255,0) 0%, #fff 40%);
-  padding-top: 16px;
+  padding-top: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #ffffff 45%);
 }
 
 .ttpro-step-next {
   width: 100%;
-  background: #2563eb;
   border: none;
-  color: #fff;
+  border-radius: 10px;
+  background: linear-gradient(120deg, #2563eb, #4f46e5);
+  color: #ffffff;
   font-size: 16px;
   font-weight: 600;
-  padding: 12px 18px;
-  border-radius: 8px;
+  padding: 14px 18px;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
-  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.18);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+  box-shadow: 0 12px 28px rgba(59, 130, 246, 0.25);
 }
 
 .ttpro-step-next:hover {
-  background: #1d4ed8;
+  filter: brightness(1.05);
 }
 
 .ttpro-step-next:active {
@@ -204,17 +243,23 @@
 }
 
 .ttpro-step-next[disabled] {
-  background: #93c5fd;
   cursor: not-allowed;
+  background: #94a3b8;
   box-shadow: none;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 720px) {
   .ttpro-pdv-editor {
     padding: 20px 16px;
+    border-radius: 0;
+    box-shadow: none;
   }
 
   .ttpro-step-body {
     min-height: 200px;
+  }
+
+  .ttpro-options {
+    grid-template-columns: 1fr;
   }
 }

--- a/plugin/assets/pdv-editor.js
+++ b/plugin/assets/pdv-editor.js
@@ -1,170 +1,105 @@
-(function($){
-  function toArray(value){
-    if (Array.isArray(value)){
-      return value;
-    }
-    if (value === undefined || value === null){
-      return [];
-    }
+(function ($) {
+  'use strict';
+
+  function toArray(value) {
+    if (Array.isArray(value)) return value;
+    if (value === undefined || value === null) return [];
     return [value];
   }
 
-  function normalizeValues(value){
-    return toArray(value).map(function(item){
-      if (item === undefined || item === null){
-        return '';
-      }
+  function normalizeValues(value) {
+    return toArray(value).map(function (item) {
+      if (item === undefined || item === null) return '';
       return String(item).trim();
-    });
-  }
-
-  function normalizeConditionValue(value){
-    var raw = normalizeValues(value);
-    var parts = [];
-
-    raw.forEach(function(item){
-      if (!item){
-        return;
-      }
-      var needsSplit = item.indexOf('|') !== -1 || item.indexOf(',') !== -1;
-      if (needsSplit){
-        item.split(/[|,]/).forEach(function(piece){
-          var trimmed = String(piece || '').trim();
-          if (trimmed){
-            parts.push(trimmed);
-          }
-        });
-        return;
-      }
-      parts.push(item);
-    });
-
-    return parts.filter(function(item){
-      return item !== '';
     });
   }
 
   var htmlDecodeEl = null;
 
-  function decodeHtmlEntities(str){
-    if (typeof str !== 'string'){ return str; }
-    if (str.indexOf('&') === -1){ return str; }
-    if (!htmlDecodeEl){
+  function decodeHtmlEntities(str) {
+    if (typeof str !== 'string') return str;
+    if (str.indexOf('&') === -1) return str;
+    if (!htmlDecodeEl) {
       htmlDecodeEl = document.createElement('textarea');
     }
     htmlDecodeEl.innerHTML = str;
     return htmlDecodeEl.value;
   }
 
-  function parseConditions(raw){
-    if (!raw){
-      return [];
+  function parseShowIf($field) {
+    var cached = $field.data('ttproShowIfCache');
+    if (cached !== undefined) return cached;
+
+    var raw = $field.attr('data-show-if');
+    if (!raw) {
+      $field.data('ttproShowIfCache', null);
+      return null;
     }
-    var text = String(raw);
-    if (!text){
-      return [];
-    }
-    var decoded = decodeHtmlEntities(text);
+
+    var text = decodeHtmlEntities(String(raw));
+    var parsed = null;
+
     try {
-      var parsed = JSON.parse(decoded);
-      if (Array.isArray(parsed)){
-        return parsed.map(function(item){
-          if (!item || typeof item !== 'object'){
-            return null;
-          }
-          var id = '';
-          if (item.id !== undefined && item.id !== null){
-            id = String(item.id);
-          }
-          var values = normalizeConditionValue(item.value);
-          if (!id || !values.length){
-            return null;
-          }
-          return { id: id, value: values };
-        }).filter(Boolean);
-      }
-      if (parsed && typeof parsed === 'object'){
-        var singleId = '';
-        if (parsed.id !== undefined && parsed.id !== null){
-          singleId = String(parsed.id);
-        }
-        var singleValues = normalizeConditionValue(parsed.value);
-        if (!singleId || !singleValues.length){
-          return [];
-        }
-        return [{ id: singleId, value: singleValues }];
-      }
-    } catch (e){
-      try {
-        if (decoded !== text){
-          var reparsed = JSON.parse(text);
-          if (Array.isArray(reparsed)){
-            return reparsed.map(function(item){
-              if (!item || typeof item !== 'object'){
-                return null;
-              }
-              var rid = '';
-              if (item.id !== undefined && item.id !== null){
-                rid = String(item.id);
-              }
-              var rvalues = normalizeConditionValue(item.value);
-              if (!rid || !rvalues.length){
-                return null;
-              }
-              return { id: rid, value: rvalues };
-            }).filter(Boolean);
-          }
-          if (reparsed && typeof reparsed === 'object'){
-            var ridSingle = '';
-            if (reparsed.id !== undefined && reparsed.id !== null){
-              ridSingle = String(reparsed.id);
-            }
-            var rSingleValues = normalizeConditionValue(reparsed.value);
-            if (!ridSingle || !rSingleValues.length){
-              return [];
-            }
-            return [{ id: ridSingle, value: rSingleValues }];
-          }
-        }
-      } catch (err){}
+      parsed = JSON.parse(text);
+    } catch (err) {
+      parsed = null;
     }
-    return [];
+
+    function normalizeCondition(cond) {
+      if (!cond || typeof cond !== 'object') return null;
+      var id = '';
+      if (cond.id !== undefined && cond.id !== null) {
+        id = String(cond.id);
+      }
+      if (!id) return null;
+      var values = normalizeValues(cond.value);
+      if (!values.length) return null;
+      return { id: id, value: values };
+    }
+
+    var result = null;
+
+    if (Array.isArray(parsed)) {
+      result = parsed.map(normalizeCondition).filter(Boolean);
+      if (!result.length) result = null;
+    } else {
+      var single = normalizeCondition(parsed);
+      result = single ? [single] : null;
+    }
+
+    $field.data('ttproShowIfCache', result);
+    return result;
   }
 
-  function shouldDisplayField(conditions, answers){
-    var conds = Array.isArray(conditions) ? conditions : [conditions];
-    if (!conds.length){
-      return true;
-    }
-    return conds.every(function(cond){
-      if (!cond || !cond.id){
-        return true;
-      }
-      var expectedValues = normalizeConditionValue(cond.value);
-      if (expectedValues.length === 0){
-        return false;
-      }
+  function shouldShowField($field, answers) {
+    var conditions = parseShowIf($field);
+    if (!conditions || !conditions.length) return true;
+
+    return conditions.every(function (cond) {
+      if (!cond || !cond.id) return true;
       var actualValues = normalizeValues(answers[cond.id]);
-      if (actualValues.length === 0){
-        return false;
+      if (!actualValues.length) return false;
+      var expectedValues = normalizeValues(cond.value);
+      if (!expectedValues.length) return false;
+      for (var i = 0; i < expectedValues.length; i++) {
+        if (actualValues.indexOf(expectedValues[i]) !== -1) {
+          return true;
+        }
       }
-      return expectedValues.some(function(expected){
-        return actualValues.indexOf(expected) !== -1;
-      });
+      return false;
     });
   }
 
-  function readFieldAnswer($field){
+  function readAnswer($field) {
     var type = ($field.attr('data-field-type') || '').toLowerCase();
-    var fieldId = String($field.attr('data-field-id') || '');
 
-    if (type === 'checkbox'){
+    if (type === 'checkbox') {
       var values = [];
-      $field.find('input[type="checkbox"]').each(function(){
+      $field.find('input[type="checkbox"]').each(function () {
         var $el = $(this);
-        if ($el.prop('checked')){
+        if ($el.prop('checked')) {
           var val = $el.val();
-          if (val !== undefined && val !== null){
+          if (val !== undefined && val !== null) {
             values.push(String(val).trim());
           }
         }
@@ -172,201 +107,171 @@
       return values;
     }
 
-    if (type === 'radio' || type === 'post'){
+    if (type === 'radio' || type === 'post') {
       var $checked = $field.find('input[type="radio"]:checked').first();
-      if ($checked.length){
+      if ($checked.length) {
         var radioVal = $checked.val();
-        if (radioVal !== undefined && radioVal !== null){
+        if (radioVal !== undefined && radioVal !== null) {
           return String(radioVal).trim();
         }
       }
       return '';
     }
 
-
-    if (type === 'geo'){
-      var lat = String(($field.find('[name$="[lat]"]').val() || '')).trim();
-      var lng = String(($field.find('[name$="[lng]"]').val() || '')).trim();
-      var acc = String(($field.find('[name$="[accuracy]"]').val() || '')).trim();
-      if (!lat && !lng && !acc){
-        return '';
-      }
-      var payload = {};
-      if (lat){ payload.lat = lat; }
-      if (lng){ payload.lng = lng; }
-      if (acc){ payload.accuracy = acc; }
-      return payload;
-    }
-
-    if (type === 'photo'){
+    if (type === 'photo') {
       var fileInput = $field.find('input[type="file"]').get(0);
-      if (fileInput && fileInput.files && fileInput.files.length){
+      if (fileInput && fileInput.files && fileInput.files.length) {
         return '1';
       }
+      var fieldId = String($field.attr('data-field-id') || '');
       var hasExisting = String($field.find('[name^="ttpro_existing_photo[' + fieldId + ']"]').val() || '') === '1';
-      var removeChecked = $field.find('[name^="ttpro_remove_photo[' + fieldId + ']"]').filter(':checked').length > 0;
+      var removeChecked = $field
+        .find('[name^="ttpro_remove_photo[' + fieldId + ']"]')
+        .filter(':checked')
+        .length > 0;
       return hasExisting && !removeChecked ? '1' : '';
     }
 
-    var $select = $field.find('select');
-    if ($select.length){
+    if (type === 'geo') {
+      var lat = String(($field.find('[name$="[lat]"]').val() || '')).trim();
+      var lng = String(($field.find('[name$="[lng]"]').val() || '')).trim();
+      var accuracy = String(($field.find('[name$="[accuracy]"]').val() || '')).trim();
+      if (!lat && !lng && !accuracy) {
+        return '';
+      }
+      var payload = {};
+      if (lat) payload.lat = lat;
+      if (lng) payload.lng = lng;
+      if (accuracy) payload.accuracy = accuracy;
+      return payload;
+    }
+
+    var $select = $field.find('select').first();
+    if ($select.length) {
       var selectVal = $select.val();
-      if (Array.isArray(selectVal)){
-        return selectVal.map(function(v){
-          if (v === undefined || v === null){
-            return '';
-          }
-          return String(v).trim();
+      if (Array.isArray(selectVal)) {
+        return selectVal.map(function (item) {
+          if (item === undefined || item === null) return '';
+          return String(item).trim();
         });
       }
-      if (selectVal === undefined || selectVal === null){
+      if (selectVal === undefined || selectVal === null) {
         return '';
       }
       return String(selectVal).trim();
     }
 
-    var $textarea = $field.find('textarea');
-    if ($textarea.length){
-      var taVal = $textarea.first().val();
-      if (taVal === undefined || taVal === null){
-        return '';
-      }
+    var $textarea = $field.find('textarea').first();
+    if ($textarea.length) {
+      var taVal = $textarea.val();
+      if (taVal === undefined || taVal === null) return '';
       return String(taVal).trim();
     }
 
-    var $input = $field.find('input').filter(function(){
-      var $el = $(this);
-      var typeAttr = ($el.attr('type') || '').toLowerCase();
-      if (typeAttr === 'radio' || typeAttr === 'checkbox' || typeAttr === 'hidden' || typeAttr === 'file'){
-        return false;
-      }
-      if ($el.is('[name^="ttpro_existing_photo"], [name^="ttpro_remove_photo"]')){
-        return false;
-      }
-      return true;
-    }).first();
+    var $input = $field
+      .find('input')
+      .filter(function () {
+        var $el = $(this);
+        var typeAttr = ($el.attr('type') || '').toLowerCase();
+        if (typeAttr === 'radio' || typeAttr === 'checkbox' || typeAttr === 'hidden' || typeAttr === 'file') {
+          return false;
+        }
+        if ($el.is('[name^="ttpro_existing_photo"], [name^="ttpro_remove_photo"]')) {
+          return false;
+        }
+        return true;
+      })
+      .first();
 
-    if ($input.length){
+    if ($input.length) {
       var inputVal = $input.val();
-      if (inputVal === undefined || inputVal === null){
-        return '';
-      }
+      if (inputVal === undefined || inputVal === null) return '';
       return String(inputVal).trim();
     }
 
     return '';
   }
 
-  function collectAnswers($fields){
+  function collectAnswers($fields) {
     var answers = {};
-    $fields.each(function(){
+    $fields.each(function () {
       var $field = $(this);
       var fieldId = String($field.attr('data-field-id') || '');
-      if (!fieldId){
-        return;
-      }
-      answers[fieldId] = readFieldAnswer($field);
+      if (!fieldId) return;
+      answers[fieldId] = readAnswer($field);
     });
     return answers;
   }
 
-  function getConditionsForField($field){
-    if ($field.data('ttproShowIfParsed') !== undefined){
-      return $field.data('ttproShowIfParsed');
-    }
-    var raw = $field.attr('data-show-if');
-    if (!raw){
-      $field.data('ttproShowIfParsed', null);
-      return null;
-    }
-    var parsed = parseConditions(raw);
-    if (!parsed.length){
-      $field.data('ttproShowIfParsed', null);
-      return null;
-    }
-    if (parsed.length === 1){
-      $field.data('ttproShowIfParsed', parsed[0]);
-      return parsed[0];
-    }
-    $field.data('ttproShowIfParsed', parsed);
-    return parsed;
-  }
-
-  function setFieldVisibility($field, visible){
-    if (visible){
+  function setFieldVisibility($field, visible) {
+    if (visible) {
       $field.removeClass('ttpro-field-hidden').attr('aria-hidden', 'false');
     } else {
       $field.addClass('ttpro-field-hidden').attr('aria-hidden', 'true');
     }
   }
 
-  function isFieldValid($field){
-    if (!$field || !$field.length){
-      return true;
-    }
-    if ($field.hasClass('ttpro-field-hidden')){
-      return true;
-    }
-
-    var required = String($field.attr('data-required') || '') === '1';
-    if (!required){
-      return true;
-    }
-
-    var type = ($field.attr('data-field-type') || '').toLowerCase();
-
-    if (type === 'checkbox'){
-      return $field.find('input[type="checkbox"]:checked').length > 0;
-    }
-    if (type === 'radio' || type === 'post'){
-      return $field.find('input[type="radio"]:checked').length > 0;
-    }
-    if (type === 'geo'){
-      var lat = $field.find('[name$="[lat]"]').val();
-      var lng = $field.find('[name$="[lng]"]').val();
-      return !!(lat && String(lat).trim() !== '' && lng && String(lng).trim() !== '');
-    }
-    if (type === 'photo'){
-      var fileInput = $field.find('input[type="file"]').get(0);
-      var hasFile = !!(fileInput && fileInput.files && fileInput.files.length);
-      if (hasFile){
-        return true;
-      }
-      var hasExisting = String($field.find('[name^="ttpro_existing_photo"]').val() || '') === '1';
-      var removeChecked = $field.find('[name^="ttpro_remove_photo"]').filter(':checked').length > 0;
-      return hasExisting && !removeChecked;
-    }
-
-    var $controls = $field.find('input:not([type="hidden"]), textarea, select');
-    if (!$controls.length){
-      return true;
-    }
-
-    var valid = true;
-    $controls.each(function(){
-      if (!valid){
-        return false;
-      }
-      var $el = $(this);
-      if ($el.is(':hidden') && !$el.is('select')){
-        return true;
-      }
-      var val = $el.val();
-      if (val === null || val === undefined || String(val).trim() === ''){
-        valid = false;
-      }
-    });
-
-    return valid;
+  function isFieldRequired($field) {
+    return String($field.attr('data-required') || '') === '1';
   }
 
-  function initForm($form){
-    var $fields = $form.find('.ttpro-pdv-editor-field');
-    if (!$fields.length){
-      return;
-    }
+  function hasValue($field, answers) {
+    if (!$field || !$field.length) return true;
+    if ($field.hasClass('ttpro-field-hidden')) return true;
 
-    var state = { step: 0, answers: {} };
+    var fieldId = String($field.attr('data-field-id') || '');
+    if (!fieldId) return true;
+
+    var type = ($field.attr('data-field-type') || '').toLowerCase();
+    var value = answers[fieldId];
+
+    if (type === 'checkbox') {
+      return Array.isArray(value) && value.length > 0;
+    }
+    if (type === 'radio' || type === 'post') {
+      return typeof value === 'string' && value.trim() !== '';
+    }
+    if (type === 'photo') {
+      return value === '1';
+    }
+    if (type === 'geo') {
+      return value && value.lat && value.lng;
+    }
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    }
+    if (value && typeof value === 'object') {
+      return Object.keys(value).length > 0;
+    }
+    if (typeof value === 'string') {
+      return value.trim() !== '';
+    }
+    return value !== undefined && value !== null && value !== '';
+  }
+
+  function focusField($field) {
+    if (!$field || !$field.length) return;
+    setTimeout(function () {
+      var $focusable = $field
+        .find('input:not([type="hidden"]), textarea, select, button')
+        .filter(function () {
+          var $el = $(this);
+          if ($el.is(':disabled')) return false;
+          if ($el.is('input[type="radio"], input[type="checkbox"]')) {
+            return $el.is(':visible');
+          }
+          return $el.is(':visible');
+        })
+        .first();
+      if ($focusable.length) {
+        $focusable.trigger('focus');
+      }
+    }, 30);
+  }
+
+  function initForm($form) {
+    var $fields = $form.find('.ttpro-pdv-editor-field');
+    if (!$fields.length) return;
 
     var $stepIndicator = $form.find('.ttpro-step-indicator');
     var $progressBar = $form.find('.ttpro-step-progress-bar');
@@ -375,131 +280,118 @@
     var $prevBtn = $form.find('.ttpro-step-prev');
 
     var defaultNextLabel = $nextBtn.data('default-label') || $nextBtn.text();
-    var finalNextLabel = $nextBtn.data('final-label') || defaultNextLabel;
+    var finalNextLabel = $nextBtn.data('final-label') || $nextBtn.text();
 
-    function getVisibleFields(){
-      return $fields.filter(function(){
+    var state = {
+      step: 0,
+      answers: collectAnswers($fields)
+    };
+
+    function getVisibleFields() {
+      return $fields.filter(function () {
         return !$(this).hasClass('ttpro-field-hidden');
       });
     }
 
-    function clampStep(){
-      var total = getVisibleFields().length;
-      if (!total){
+    function applyConditions() {
+      $fields.each(function () {
+        var $field = $(this);
+        var visible = shouldShowField($field, state.answers);
+        setFieldVisibility($field, visible);
+      });
+    }
+
+    function clampStep() {
+      var $visible = getVisibleFields();
+      var total = $visible.length;
+      if (!total) {
         state.step = 0;
         return;
       }
-      if (state.step >= total){
+      if (state.step >= total) {
         state.step = total - 1;
       }
-      if (state.step < 0){
+      if (state.step < 0) {
         state.step = 0;
       }
     }
 
-    function focusCurrent($current){
-      if (!$current || !$current.length){
-        return;
-      }
-      setTimeout(function(){
-        var $focusable = $current.find('input:not([type="hidden"]), textarea, select').filter(function(){
-          var $el = $(this);
-          if ($el.is(':disabled')){
-            return false;
-          }
-          if ($el.is('input[type="radio"], input[type="checkbox"]')){
-            return $el.is(':visible');
-          }
-          return $el.is(':visible');
-        }).first();
-        if ($focusable.length){
-          $focusable.trigger('focus');
-        }
-      }, 10);
-    }
-
-    function updateUI(){
-      clampStep();
+    function updateUI() {
       var $visible = getVisibleFields();
       var total = $visible.length;
 
       $fields.removeClass('ttpro-step-active ttpro-step-hidden-step');
 
-      if (!total){
+      if (!total) {
+        $fields.addClass('ttpro-step-hidden-step');
         $stepIndicator.text('0/0');
         $progressBar.css('width', '0%');
-        $progress.attr('aria-valuenow', 0);
+        if ($progress.length) {
+          $progress.attr('aria-valuenow', 0);
+        }
         $nextBtn.prop('disabled', true);
         $prevBtn.prop('disabled', true);
         return;
       }
 
+      $fields.addClass('ttpro-step-hidden-step');
+
       var $current = $visible.eq(state.step);
-      $visible.addClass('ttpro-step-hidden-step');
-      if ($current.length){
+      if ($current.length) {
         $current.removeClass('ttpro-step-hidden-step').addClass('ttpro-step-active');
       }
 
       var isLast = state.step === total - 1;
       var pct = total > 1 ? Math.round((state.step / (total - 1)) * 100) : 100;
-      if (!isFinite(pct)){
-        pct = 0;
-      }
+      if (!isFinite(pct)) pct = 0;
 
       $stepIndicator.text((state.step + 1) + '/' + total);
       $progressBar.css('width', pct + '%');
-      $progress.attr('aria-valuenow', pct);
+      if ($progress.length) {
+        $progress.attr('aria-valuenow', pct);
+      }
       $nextBtn.text(isLast ? finalNextLabel : defaultNextLabel);
       $prevBtn.prop('disabled', state.step === 0);
 
-      var canAdvance = isFieldValid($current);
-      $nextBtn.prop('disabled', !canAdvance);
+      var required = $current.length && isFieldRequired($current);
+      if (required) {
+        $nextBtn.prop('disabled', !hasValue($current, state.answers));
+      } else {
+        $nextBtn.prop('disabled', false);
+      }
 
-      focusCurrent($current);
+      focusField($current);
     }
 
-    function applyConditions(answers){
-
-      $fields.each(function(){
-        var $field = $(this);
-        var conditions = getConditionsForField($field);
-        if (!conditions){
-          setFieldVisibility($field, true);
-          return;
-        }
-        var visible = shouldDisplayField(conditions, answers);
-        setFieldVisibility($field, visible);
-      });
-    }
-
-    function refresh(){
-      var answers = collectAnswers($fields);
-      state.answers = answers;
-      applyConditions(answers);
-
+    function refresh() {
+      state.answers = collectAnswers($fields);
+      applyConditions();
+      clampStep();
       updateUI();
     }
 
-    $form.on('change input', 'input, select, textarea', function(){
+    $form.on('change ttpro:refresh input', 'input, select, textarea', function () {
       refresh();
     });
 
-    $nextBtn.on('click', function(e){
-      e.preventDefault();
+    $nextBtn.on('click', function (event) {
+      event.preventDefault();
+      if ($nextBtn.prop('disabled')) return;
+
       var $visible = getVisibleFields();
-      if (!$visible.length){
-        return;
-      }
+      if (!$visible.length) return;
+
       var $current = $visible.eq(state.step);
-      if (!isFieldValid($current)){
-        focusCurrent($current);
+      var required = $current.length && isFieldRequired($current);
+      if (required && !hasValue($current, state.answers)) {
+        focusField($current);
         return;
       }
-      var isLast = state.step >= ($visible.length - 1);
-      if (isLast){
+
+      if (state.step >= $visible.length - 1) {
         var formEl = $form.get(0);
-        if (formEl){
-          if (typeof formEl.requestSubmit === 'function'){
+        if (formEl) {
+          if (typeof formEl.requestSubmit === 'function') {
             formEl.requestSubmit();
           } else {
             formEl.submit();
@@ -507,25 +399,24 @@
         }
         return;
       }
+
       state.step += 1;
       refresh();
-
     });
 
-    $prevBtn.on('click', function(e){
-      e.preventDefault();
-      if (state.step > 0){
+    $prevBtn.on('click', function (event) {
+      event.preventDefault();
+      if (state.step > 0) {
         state.step -= 1;
         refresh();
-
       }
     });
 
     refresh();
   }
 
-  $(function(){
-    $('.ttpro-pdv-editor-form').each(function(){
+  $(function () {
+    $('.ttpro-pdv-editor-form').each(function () {
       initForm($(this));
     });
   });


### PR DESCRIPTION
## Summary
- rebuild the PDV editor JavaScript to reuse the conditional navigation logic from the PWA form
- refresh the PDV editor stylesheet to match the new single-step presentation and responsive layout
- ensure the shortcode output includes normalized show_if metadata so the editor honors conditional visibility

## Testing
- php -l plugin/ttpro-wpapi.php

------
https://chatgpt.com/codex/tasks/task_e_68d48f8338f08327bf416c43ff7b1655